### PR TITLE
Feature/query builder

### DIFF
--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -3,8 +3,8 @@ const { usersService } = require('../services');
 
 module.exports = {
   list: catchAsync(async (req, res) => {
-    const { page, perPage } = req.query;
-    const response = await usersService.list({ page, perPage });
+    const { page, perPage, sortBy } = req.query;
+    const response = await usersService.list({ page, perPage, sortBy });
 
     if (!response || response.data.length === 0) {
       return res.status(204).end();

--- a/src/helpers/queryHelper.js
+++ b/src/helpers/queryHelper.js
@@ -1,7 +1,7 @@
 const { ApplicationError } = require('../utils');
 
 module.exports.queryHelper = (options) => {
-  const sort = options.sortBy.trim() || 'createdAt:desc';
+  const sort = options.sortBy || 'createdAt:desc';
   const limit = parseInt(options.perPage || 10, 10);
   let skip = parseInt(options.page || 1, 10);
 
@@ -28,13 +28,13 @@ module.exports.queryHelper = (options) => {
     $skip: skip,
   });
 
-  const [sortKey, sortVvalue] = sort.split(':');
-  if (!['asc', 'desc'].includes(sortVvalue)) {
+  const [sortKey, sortValue] = sort.trim().split(':');
+  if (!['asc', 'desc'].includes(sortValue)) {
     throw new ApplicationError("Sort order must be one of the following: 'asc' or 'desc'", 400);
   }
 
   pipeline[0].$facet.data.push({
-    $sort: { [sortKey]: sortVvalue === 'desc' ? -1 : 1 },
+    $sort: { [sortKey]: sortValue === 'desc' ? -1 : 1 },
   });
 
   return pipeline;

--- a/src/helpers/queryHelper.js
+++ b/src/helpers/queryHelper.js
@@ -1,4 +1,7 @@
+const { ApplicationError } = require('../utils');
+
 module.exports.queryHelper = (options) => {
+  const sort = options.sortBy.trim() || 'createdAt:desc';
   const limit = parseInt(options.perPage || 10, 10);
   let skip = parseInt(options.page || 1, 10);
 
@@ -23,6 +26,15 @@ module.exports.queryHelper = (options) => {
 
   pipeline[0].$facet.data.push({
     $skip: skip,
+  });
+
+  const [sortKey, sortVvalue] = sort.split(':');
+  if (!['asc', 'desc'].includes(sortVvalue)) {
+    throw new ApplicationError("Sort order must be one of the following: 'asc' or 'desc'", 400);
+  }
+
+  pipeline[0].$facet.data.push({
+    $sort: { [sortKey]: sortVvalue === 'desc' ? -1 : 1 },
   });
 
   return pipeline;

--- a/src/helpers/validations/users.validation.js
+++ b/src/helpers/validations/users.validation.js
@@ -4,6 +4,7 @@ const list = {
   query: yup.object().shape({
     page: yup.number().integer(),
     perPage: yup.number().integer(),
+    sortBy: yup.string(),
   }),
 };
 

--- a/src/tests/integration/users.test.js
+++ b/src/tests/integration/users.test.js
@@ -82,6 +82,16 @@ describe('User Endpoints', () => {
       });
     });
 
+    test('Should return 204 - No Content', async () => {
+      const page = 2;
+      const perPage = 10;
+      const response = await request(app)
+        .get(`${baseURL}?page=${page}&perPage=${perPage}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(204);
+    });
+
     test('Should return 400 - Bad Request if sortBy has invalid input', async () => {
       const page = 1;
       const perPage = 10;
@@ -94,16 +104,6 @@ describe('User Endpoints', () => {
 
       const { body } = response;
       expect(body).toHaveProperty('message', "Sort order must be one of the following: 'asc' or 'desc'");
-    });
-
-    test('Should return 204 - No Content', async () => {
-      const page = 2;
-      const perPage = 10;
-      const response = await request(app)
-        .get(`${baseURL}?page=${page}&perPage=${perPage}`)
-        .set('Authorization', `Bearer ${token}`);
-
-      expect(response.status).toBe(204);
     });
   });
 

--- a/src/tests/integration/users.test.js
+++ b/src/tests/integration/users.test.js
@@ -54,8 +54,9 @@ describe('User Endpoints', () => {
     test('Should return a list of users and metadata', async () => {
       const page = 1;
       const perPage = 10;
+      const sortBy = 'createdAt:asc';
       const response = await request(app)
-        .get(`${baseURL}?page=${page}&perPage=${perPage}`)
+        .get(`${baseURL}?page=${page}&perPage=${perPage}&sortBy=${sortBy}`)
         .set('Authorization', `Bearer ${token}`);
 
       expect(response.status).toBe(200);
@@ -79,6 +80,20 @@ describe('User Endpoints', () => {
         metadata: expect.any(Object),
         data: expect.any(Array),
       });
+    });
+
+    test('Should return 400 - Bad Request if sortBy has invalid input', async () => {
+      const page = 1;
+      const perPage = 10;
+      const sortBy = 'createdAtdesc';
+      const response = await request(app)
+        .get(`${baseURL}?page=${page}&perPage=${perPage}&sortBy=${sortBy}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(400);
+
+      const { body } = response;
+      expect(body).toHaveProperty('message', "Sort order must be one of the following: 'asc' or 'desc'");
     });
 
     test('Should return 204 - No Content', async () => {


### PR DESCRIPTION
Adding sortBy option to query builder, allowing the client to sort the contents of a list by sending `sortBy` in the query params with `key:value` (**key** and **value** must be separated by **:** in the string value).