### PR TITLE
build(docker): added docker setup for dev, test and prod environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:14
+
+RUN npm i npm@latest -g
+
+RUN mkdir /opt/node_app && chown node:node /opt/node_app
+WORKDIR /opt/node_app
+
+USER node
+
+COPY package.json package-lock.json* ./
+
+RUN npm install && npm cache clean --force
+
+ENV PATH /opt/node_app/node_modules/.bin:$PATH
+
+WORKDIR /opt/node_app/app
+
+COPY . .
+
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **Code Analisys**: [Codecov](https://codecov.io)/[Codacy](https://www.codacy.com);
 - **Linting:** [ESLint](https://eslint.org)/[Prettier](https://prettier.io);
 - **API Documentation:** [Swagger](https://swagger.io)/[Postman](https://www.postman.com);
+- **[Docker](https://docker.com) Support**
 
 > This boilerplate is also available with Sequelize/PostgreSQL on this [repository](https://github.com/lucas-a-pelegrino/node-bloodboiler-sequelized)!
 
@@ -72,6 +73,22 @@ Testing
 $ npm test
 $ yarn test
 ```
+
+### Docker
+
+Bloodboiler comes with Docker support, you can develop and test your code using Docker for minimal configuration, Nodemon takes care of restarting the the application inside Docker so you can code locally.
+
+```sh
+# Code Locally with:
+$ npm run docker:dev
+$ yarn docker:dev
+
+# Run Test Suites inside Docker:
+$ npm run docker:test
+$ yarn docker:test
+```
+
+> NOTE: In order to use the methods listed above, make sure you have Docker installed on your local machine!
 
 ## Documentation
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  backend:
+    environment:
+      - DB_HOST=database
+    command: ['npm', 'run', 'start:dev', '-L']

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,5 @@
+version: '3'
+
+services:
+  backend:
+    command: ['npm', 'start']

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  backend:
+    environment:
+      - DB_HOST=database
+    command: ['npm', 'test']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+
+services:
+  database:
+    container_name: bloodboiler-database
+    image: mongo:latest
+    ports:
+      - '27017:27017'
+    volumes:
+      - dbdata:/data/db
+    logging:
+      driver: none
+    networks:
+      - app-network
+
+  backend:
+    container_name: bloodboiler-backend
+    build: .
+    image: bloodboiler
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/opt/node_app/app
+    networks:
+      - app-network
+    depends_on:
+      - database
+
+volumes:
+  dbdata:
+
+networks:
+  app-network:
+    driver: bridge

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "start:staging": "NODE_ENV=staging node app.js",
     "start:dev": "NODE_ENV=development nodemon app.js",
     "start:debug": "NODE_ENV=development node --inspect-brk=5858 app.js",
+    "docker:prod": "docker-compose -f docker-compose.yml -f docker-compose.prod.yml up",
+    "docker:dev": "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up",
+    "docker:test": "docker-compose -f docker-compose.yml -f docker-compose.test.yml up",
     "test": "jest -i",
     "test:coverage": "jest -i && codecov"
   },


### PR DESCRIPTION
- Added **[Docker](https://www.docker.com)** support for the boilerplate, allowing developers to code without setting up environments, such as installing databases;
- Use the commands: `yarn docker:dev` to code locally using Docker and [Nodemon](https://github.com/remy/nodemon);
- Run **Test Suites** using docker with `yarn docker:test`; 